### PR TITLE
Fix path traversal via malicious emotion names

### DIFF
--- a/src/extension/preview.ts
+++ b/src/extension/preview.ts
@@ -71,9 +71,11 @@ function openPreviewPanel(context: vscode.ExtensionContext, pack: CharPack): voi
 
 function buildPreviewHtml(webview: vscode.Webview, pack: CharPack): string {
   // Resolve emotion PNG URIs — skip emotions with no file on disk
+  // Defense-in-depth: verify resolved path stays within pack.dir
   const spriteUris: Record<string, string> = {};
   for (const emotion of pack.emotions) {
-    const imgPath = path.join(pack.dir, `${emotion}.png`);
+    const imgPath = path.resolve(pack.dir, `${emotion}.png`);
+    if (!imgPath.startsWith(pack.dir + path.sep)) { continue; }
     if (fs.existsSync(imgPath)) {
       spriteUris[emotion] = webview.asWebviewUri(vscode.Uri.file(imgPath)).toString();
     }

--- a/src/extension/providers.ts
+++ b/src/extension/providers.ts
@@ -139,7 +139,8 @@ export class CodeChanViewProvider implements vscode.WebviewViewProvider {
       customAnimationsJson = JSON.stringify(communityPack.animations);
       const sprites: Record<string, string> = {};
       for (const emotion of communityPack.emotions) {
-        const imgPath = path.join(communityPack.dir, `${emotion}.png`);
+        const imgPath = path.resolve(communityPack.dir, `${emotion}.png`);
+        if (!imgPath.startsWith(communityPack.dir + path.sep)) { continue; }
         if (fs.existsSync(imgPath)) {
           sprites[emotion] = this.toFileUri(webview, imgPath);
         }


### PR DESCRIPTION
## Summary
- Validate emotion names at load time in `charLoader.ts` — only alphanumeric, hyphens, and underscores allowed
- Add defense-in-depth bounds check in `preview.ts` and `providers.ts` — verify resolved file path stays within the pack directory before reading

Closes #2

## Test plan
- [ ] Create a test pack with an emotion like `../../etc/passwd` — verify it's rejected at load time
- [ ] Normal packs with emotions like `idle`, `happy`, `sad` still load correctly
- [ ] Build passes

🔒 Security fix — generated with [Claude Code](https://claude.com/claude-code)