### PR TITLE
Fix script injection via string interpolation in main panel

### DIFF
--- a/src/extension/providers.ts
+++ b/src/extension/providers.ts
@@ -356,11 +356,11 @@ export class CodeChanViewProvider implements vscode.WebviewViewProvider {
 
   <script nonce="${nonce}">
     window.CLIPPY_ANIMATIONS   = ${animationsJson};
-    window.CLIPPY_FALLBACK     = "${fallbackUri}";
-    window.CLIPPY_CHARACTER    = "${character}";
-    window.CAT_SPRITE          = "${catSpriteUri}";
-    window.IS_CAT              = ${isCat};
-    window.CHARACTER_MODE      = "${characterMode}";
+    window.CLIPPY_FALLBACK     = ${JSON.stringify(fallbackUri)};
+    window.CLIPPY_CHARACTER    = ${JSON.stringify(character)};
+    window.CAT_SPRITE          = ${JSON.stringify(catSpriteUri)};
+    window.IS_CAT              = ${JSON.stringify(isCat)};
+    window.CHARACTER_MODE      = ${JSON.stringify(characterMode)};
     window.STATIC_MOOD_SPRITES = ${staticSpritesJson};
     window.CUSTOM_ANIMATIONS   = ${customAnimationsJson};
   </script>


### PR DESCRIPTION
## Summary
- Replace `"${fallbackUri}"`, `"${character}"`, `"${catSpriteUri}"`, `"${characterMode}"` with `JSON.stringify()` calls
- This prevents string breakout attacks where a crafted community pack ID containing `"; malicious_code(); "` could execute arbitrary code inside the nonced script block

Closes #3

## Test plan
- [ ] All built-in characters (clippy, cat, kaen, ren, yuki) render correctly
- [ ] Community character packs still load and display
- [ ] Build passes

🔒 Security fix — generated with [Claude Code](https://claude.com/claude-code)